### PR TITLE
Allow tagged nodes to authenticate

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+result
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1663850217,
+        "narHash": "sha256-tp9nXo1/IdN/xN9m06ryy0QUAEfoN6K56ObM/1QTAjc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ae1dc133ea5f1538d035af41e5ddbc2ebcb67b90",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "A basic Go web server setup";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils }:
+    utils.lib.eachSystem [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ] (system:
+      let
+        pkgs =
+          import nixpkgs {
+            inherit system;
+            overlays = [
+              (final: prev: {
+                go = prev.go_1_19;
+                buildGoModule = prev.buildGo119Module;
+              })
+            ];
+          };
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [ go gopls gotools go-tools ];
+        };
+      });
+}

--- a/module.go
+++ b/module.go
@@ -1,7 +1,6 @@
 package tscaddy
 
 import (
-	"fmt"
 	"log"
 	"net"
 	"net/http"
@@ -146,7 +145,8 @@ func (ta TailscaleAuth) Authenticate(w http.ResponseWriter, r *http.Request) (ca
 	}
 
 	if len(info.Node.Tags) != 0 {
-		return user, false, fmt.Errorf("node %s has tags", info.Node.Hostinfo.Hostname())
+		info.UserProfile.LoginName = strings.Replace(info.Node.Tags[0], ":", "___", -1) + "@tags.in.your.tailnet"
+		info.UserProfile.DisplayName = "A tagged node with tags: " + strings.Join(info.Node.Tags, ", ")
 	}
 
 	var tailnet string


### PR DESCRIPTION
The basic logic here is that we want tagged machines to be able to authenticate with Tailscale auth. The main problem here is that our identity model is usually one to one (one machine has one owner) but tags make this complicated (one machine can have n tags). As a stick in the mud, I propose that we allow tagged machines to connect with Tailscale auth but the first tag is the one that has "identity power".

This decision was made arbitrarily. It should probably be brought up in an eng meeting, but this works enough to make it work on my Steam Deck:

![FdWjuNcWAAEiNIJ](https://user-images.githubusercontent.com/529003/192013867-023a97fd-72c0-483c-be95-e8c1bfe35b84.jpeg)

(pictured: a Valve Steam Deck running Firefox connected to Jenkins over Tailscale, proving that both Jenkins is configured to use Tailscale for auth and that a tagged node can authenticate to Jenkins)

## Points of contention

1. I transformed `tag:name` to `tag___name` so that it's less likely to collide with an actual human user
2. It only picks the first tag (which may not pan out in the real world)