### PR TITLE
Update getListener

### DIFF
--- a/module.go
+++ b/module.go
@@ -1,6 +1,7 @@
 package tscaddy
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
@@ -40,7 +41,7 @@ func init() {
 //
 // Auth keys can be provided in environment variables of the form TS_AUTHKEY_<HOST>.  If
 // no host is specified in the address, the environment variable TS_AUTHKEY will be used.
-func getListener(_, addr string) (net.Listener, error) {
+func getListener(_ context.Context, _, addr string, _ net.ListenConfig) (any, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
To conform with new API introduced in https://github.com/caddyserver/caddy/pull/5089.

The code you currently have works with Caddy 2.6.0 and 2.6.1, but starting with 2.6.2 the signature for `getListener` is changing, so that's what this patch will be for. When you merge it you'll need to update your go.mod to use the latest commit or version of Caddy.

This is just a quick patch I made in the web editor. So I dunno if it compiles, heh.

Sorry for the change :sweat_smile: (You're the only user of this API so far)