### PR TITLE
Add ControlURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,36 @@ However, having a single Caddy site connect to separate Tailscale nodes doesn't
 quite work correctly. If this is something you actually need, please open an
 issue.
 
+#### Alternative ControlURL
+
+To use with a custom coordination server (Headscale) you can include your ControlURL with the listen network.
+
+```
+:80 {
+  bind tailscale/example.de/a
+}
+
+:80 {
+  bind tailscale/example.de/b
+}
+```
+
+It also supports specifying the used protocol (defaults to tcp):
+
+```
+:80 {
+  bind tailscale/example.de/udp/a
+}
+
+:80 {
+  bind tailscale/udp/b
+}
+```
+
+Current shortcommings:
+- no support for path with ControlURL, 
+- it defaults to HTTPS for connection to custom control server
+
 ### HTTPS support
 
 At this time, the Tailscale plugin for Caddy doesn't support using Caddy's
@@ -185,4 +215,43 @@ For example:
 
 ```
 xcaddy tailscale-proxy --from "tailscale/myhost:80" --to localhost:8000
+```
+
+## Caddy transport provider
+
+You can also specifiy tailscale as protocol to be used by caddy to proxy to your application.
+
+```json
+{
+ {
+  "apps": {
+    "http": {
+      "servers": {
+        "status": {
+          "listen": [
+            "tailscale/example.com/status:80"
+          ],
+          "routes": [
+            {
+              "handle": [
+                {
+                  "handler": "reverse_proxy",
+                  "upstreams": [
+                    {
+                      "dial": "node1:3000"
+                    }
+                  ],
+                  "transport": {
+                    "protocol": "tailscale",
+                    "controlURL": "https://example.com"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}
 ```

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/caddyserver/caddy/v2 v2.7.3
 	go.uber.org/zap v1.25.0
-	tailscale.com v1.1.1-0.20230810153433-3d56cafd7d23
+	tailscale.com v1.58.2
 )
 
 require (

--- a/module.go
+++ b/module.go
@@ -104,6 +104,12 @@ func getServer(_, addr string) (*tsnetServerDestructor, error) {
 			},
 		}
 
+		// Setting ControlURL to "TS_CONTROL_URL". If empty or not found will default to default of tsnet "https://controlplane.tailscale.com"
+		controlUrl, controlUrlFound := os.LookupEnv("TS_CONTROL_URL")
+		if controlUrlFound && controlUrl != "" {
+			s.ControlURL = controlUrl
+		}
+
 		if host != "" {
 			// Set authkey to "TS_AUTHKEY_<HOST>".  If empty,
 			// fall back to "TS_AUTHKEY".

--- a/transport.go
+++ b/transport.go
@@ -10,8 +10,9 @@ import (
 )
 
 type TailscaleCaddyTransport struct {
-	logger *zap.Logger
-	server *tsnetServerDestructor
+	logger     *zap.Logger
+	server     *tsnetServerDestructor
+	ControlURL string `json:"controlURL,omitempty"`
 }
 
 func (t *TailscaleCaddyTransport) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
@@ -21,7 +22,7 @@ func (t *TailscaleCaddyTransport) UnmarshalCaddyfile(d *caddyfile.Dispenser) err
 func (t *TailscaleCaddyTransport) Provision(context caddy.Context) error {
 	t.logger = context.Logger()
 
-	s, err := getServer("", "caddy-tsnet-client:80")
+	s, err := getServer("", "caddy-tsnet-client:80", t.ControlURL)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds the functionality to select the controlURL via env variable. 

The small addition was driven by the desire to use caddy-tailscale with headscale.

EDIT:
Just saw #18 and will try to apply the mentioned config option to this PR.