### PR TITLE
Support tailscale configuration via Caddy configuration

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,5 +1,12 @@
 {
 	order tailscale_auth after basicauth
+	tailscale {
+		auth_key "tskey-auth-"
+
+		caddy {
+			auth_key "tskey-auth-caddy"
+		}
+	}
 }
 
 :80 {

--- a/app.go
+++ b/app.go
@@ -35,12 +35,17 @@ func (TSApp) CaddyModule() caddy.ModuleInfo {
 }
 
 func (t *TSApp) Provision(ctx caddy.Context) error {
-	app.LoadOrStore(authUsageKey, t.DefaultAuthKey)
-	app.LoadOrStore(ephemeralKey, t.Ephemeral)
-
 	for _, svr := range t.Servers {
-		app.LoadOrStore(svr.name, svr)
+		if t.Ephemeral {
+			svr.Ephemeral = t.Ephemeral
+		}
+		if svr.AuthKey == "" {
+			svr.AuthKey = t.DefaultAuthKey
+		}
 	}
+
+	app = t
+
 	return nil
 }
 
@@ -59,5 +64,4 @@ func (t *TSApp) Stop() error {
 	return nil
 }
 
-// var _ caddyfile.Unmarshaler = (*TSApp)(nil)
 var _ caddy.App = (*TSApp)(nil)

--- a/app.go
+++ b/app.go
@@ -7,6 +7,16 @@ type TSApp struct {
 	DefaultAuthKey string `json:"auth_key,omitempty" caddy:"namespace=tailscale.auth_key"`
 
 	Ephemeral bool `json:"ephemeral,omitempty" caddy:"namespace=tailscale.ephemeral"`
+
+	Servers map[string]TSServer `json:"servers,omitempty" caddy:"namespace=tailscale"`
+}
+
+type TSServer struct {
+	AuthKey string `json:"auth_key,omitempty" caddy:"namespace=auth_key"`
+
+	Ephemeral bool `json:"ephemeral,omitempty" caddy:"namespace=tailscale.ephemeral"`
+
+	name string
 }
 
 func (TSApp) CaddyModule() caddy.ModuleInfo {

--- a/app.go
+++ b/app.go
@@ -61,6 +61,7 @@ func (t *TSApp) Start() error {
 }
 
 func (t *TSApp) Stop() error {
+	app = nil
 	return nil
 }
 

--- a/app.go
+++ b/app.go
@@ -1,6 +1,14 @@
 package tscaddy
 
-import "github.com/caddyserver/caddy/v2"
+import (
+	"errors"
+
+	"github.com/caddyserver/caddy/v2"
+)
+
+func init() {
+	caddy.RegisterModule(TSApp{})
+}
 
 type TSApp struct {
 	// DefaultAuthKey is the default auth key to use for Tailscale if no other auth key is specified.

--- a/app.go
+++ b/app.go
@@ -1,8 +1,6 @@
 package tscaddy
 
 import (
-	"errors"
-
 	"github.com/caddyserver/caddy/v2"
 )
 
@@ -34,34 +32,13 @@ func (TSApp) CaddyModule() caddy.ModuleInfo {
 	}
 }
 
-func (t *TSApp) Provision(ctx caddy.Context) error {
-	for _, svr := range t.Servers {
-		if t.Ephemeral {
-			svr.Ephemeral = t.Ephemeral
-		}
-		if svr.AuthKey == "" {
-			svr.AuthKey = t.DefaultAuthKey
-		}
-	}
-
-	app = t
-
-	return nil
-}
-
-func (t *TSApp) Validate() error {
-	if t.DefaultAuthKey == "" {
-		return errors.New("auth_key must be set")
-	}
-	return nil
-}
-
 func (t *TSApp) Start() error {
+	tsapp.Store(t)
 	return nil
 }
 
 func (t *TSApp) Stop() error {
-	app = nil
+	tsapp.CompareAndSwap(t, nil)
 	return nil
 }
 

--- a/app.go
+++ b/app.go
@@ -1,0 +1,17 @@
+package tscaddy
+
+import "github.com/caddyserver/caddy/v2"
+
+type TSApp struct {
+	// DefaultAuthKey is the default auth key to use for Tailscale if no other auth key is specified.
+	DefaultAuthKey string `json:"auth_key,omitempty" caddy:"namespace=tailscale.auth_key"`
+
+	Ephemeral bool `json:"ephemeral,omitempty" caddy:"namespace=tailscale.ephemeral"`
+}
+
+func (TSApp) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "tailscale",
+		New: func() caddy.Module { return new(TSApp) },
+	}
+}

--- a/app.go
+++ b/app.go
@@ -25,3 +25,31 @@ func (TSApp) CaddyModule() caddy.ModuleInfo {
 		New: func() caddy.Module { return new(TSApp) },
 	}
 }
+
+func (t *TSApp) Provision(ctx caddy.Context) error {
+	app.LoadOrStore(authUsageKey, t.DefaultAuthKey)
+	app.LoadOrStore(ephemeralKey, t.Ephemeral)
+
+	for _, svr := range t.Servers {
+		app.LoadOrStore(svr.name, svr)
+	}
+	return nil
+}
+
+func (t *TSApp) Validate() error {
+	if t.DefaultAuthKey == "" {
+		return errors.New("auth_key must be set")
+	}
+	return nil
+}
+
+func (t *TSApp) Start() error {
+	return nil
+}
+
+func (t *TSApp) Stop() error {
+	return nil
+}
+
+// var _ caddyfile.Unmarshaler = (*TSApp)(nil)
+var _ caddy.App = (*TSApp)(nil)

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -11,7 +11,7 @@ func init() {
 }
 
 func parseApp(d *caddyfile.Dispenser, _ any) (any, error) {
-	app = &TSApp{
+	app := &TSApp{
 		Servers: make(map[string]TSServer),
 	}
 	if !d.Next() {

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -10,6 +10,11 @@ func init() {
 	httpcaddyfile.RegisterGlobalOption("tailscale", parseApp)
 }
 
+const (
+	authUsageKey = "auth_key"
+	ephemeralKey = "ephemeral"
+)
+
 func parseApp(d *caddyfile.Dispenser, _ any) (any, error) {
 	app := &TSApp{
 		Servers: make(map[string]TSServer),

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -10,11 +10,6 @@ func init() {
 	httpcaddyfile.RegisterGlobalOption("tailscale", parseApp)
 }
 
-const (
-	authUsageKey = "auth_key"
-	ephemeralKey = "ephemeral"
-)
-
 func parseApp(d *caddyfile.Dispenser, _ any) (any, error) {
 	app := &TSApp{
 		Servers: make(map[string]TSServer),

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -11,7 +11,7 @@ func init() {
 }
 
 func parseApp(d *caddyfile.Dispenser, _ any) (any, error) {
-	app := &TSApp{
+	app = &TSApp{
 		Servers: make(map[string]TSServer),
 	}
 	if !d.Next() {

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -1,0 +1,38 @@
+package tscaddy
+
+import (
+	"github.com/caddyserver/caddy/v2/caddyconfig"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
+)
+
+func init() {
+	httpcaddyfile.RegisterGlobalOption("tailscale", parseApp)
+}
+
+func parseApp(d *caddyfile.Dispenser, _ any) (any, error) {
+	app := new(TSApp)
+	if !d.Next() {
+		return app, d.ArgErr()
+
+	}
+
+	for nesting := d.Nesting(); d.NextBlock(nesting); {
+		switch d.Val() {
+		case "auth_key":
+			if !d.NextArg() {
+				return nil, d.ArgErr()
+			}
+			app.DefaultAuthKey = d.Val()
+		case "ephemeral":
+			app.Ephemeral = true
+		default:
+			return nil, d.Errf("unrecognized subdirective: %s", d.Val())
+		}
+	}
+
+	return httpcaddyfile.App{
+		Name:  "tailscale",
+		Value: caddyconfig.JSON(app, nil),
+	}, nil
+}

--- a/caddyfile_test.go
+++ b/caddyfile_test.go
@@ -1,0 +1,90 @@
+package tscaddy
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_ParseApp(t *testing.T) {
+	tests := []struct {
+		name    string
+		d       *caddyfile.Dispenser
+		want    string
+		wantErr bool
+	}{
+		{
+
+			name: "empty",
+			d: caddyfile.NewTestDispenser(`
+				tailscsale {}
+			`),
+			want: `{}`,
+		},
+		{
+			name: "auth_key",
+			d: caddyfile.NewTestDispenser(`
+				tailscsale {
+					auth_key abcdefghijklmnopqrstuvwxyz
+				}`),
+			want: `{"auth_key":"abcdefghijklmnopqrstuvwxyz"}`,
+		},
+		{
+			name: "ephemeral",
+			d: caddyfile.NewTestDispenser(`
+				tailscsale {
+					ephemeral
+				}`),
+			want: `{"ephemeral":true}`,
+		},
+		{
+			name: "missing auth key",
+			d: caddyfile.NewTestDispenser(`
+				tailscsale {
+					auth_key
+				}`),
+			wantErr: true,
+		},
+		{
+			name: "unknown subdirective",
+			d: caddyfile.NewTestDispenser(`
+				tailscsale {
+					foo
+				}`),
+			wantErr: true,
+		},
+	}
+
+	for _, testcase := range tests {
+		t.Run(testcase.name, func(t *testing.T) {
+			got, err := parseApp(testcase.d, nil)
+			if err != nil {
+				if !testcase.wantErr {
+					t.Errorf("parseApp() error = %v, wantErr %v", err, testcase.wantErr)
+					return
+				}
+				return
+			}
+			gotJSON := string(got.(httpcaddyfile.App).Value)
+			if diff := compareJSON(gotJSON, testcase.want, t); diff != "" {
+				t.Errorf("parseApp() diff(-got +want):\n%s", diff)
+			}
+		})
+	}
+
+}
+
+func compareJSON(s1, s2 string, t *testing.T) string {
+	var v1, v2 map[string]any
+	if err := json.Unmarshal([]byte(s1), &v1); err != nil {
+		t.Error(err)
+	}
+	if err := json.Unmarshal([]byte(s2), &v2); err != nil {
+		t.Error(err)
+	}
+
+	return cmp.Diff(v1, v2)
+}

--- a/caddyfile_test.go
+++ b/caddyfile_test.go
@@ -49,12 +49,23 @@ func Test_ParseApp(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "unknown subdirective",
+			name: "empty server",
 			d: caddyfile.NewTestDispenser(`
 				tailscsale {
 					foo
 				}`),
-			wantErr: true,
+			want: `{"servers":{"foo":{}}}`,
+		},
+		{
+			name: "tailscale with server",
+			d: caddyfile.NewTestDispenser(`
+				tailscsale {
+					foo {
+						auth_key  abcdefghijklmnopqrstuvwxyz
+					}
+				}`),
+			want:    `{"servers":{"foo":{"auth_key":"abcdefghijklmnopqrstuvwxyz"}}}`,
+			wantErr: false,
 		},
 	}
 
@@ -66,6 +77,10 @@ func Test_ParseApp(t *testing.T) {
 					t.Errorf("parseApp() error = %v, wantErr %v", err, testcase.wantErr)
 					return
 				}
+				return
+			}
+			if testcase.wantErr && err == nil {
+				t.Errorf("parseApp() err = %v, wantErr %v", err, testcase.wantErr)
 				return
 			}
 			gotJSON := string(got.(httpcaddyfile.App).Value)

--- a/caddyfile_test.go
+++ b/caddyfile_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/google/go-cmp/cmp"
@@ -97,10 +96,6 @@ func Test_ParseApp(t *testing.T) {
 			if err := json.Unmarshal([]byte(gotJSON), &app); err != nil {
 				t.Error("failed to unmarshal json into TSApp")
 			}
-			if err := app.Provision(caddy.Context{}); err != nil {
-				t.Error("failed to provision caddy app")
-			}
-
 		})
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22.0
 
 require (
 	github.com/caddyserver/caddy/v2 v2.7.3
+	github.com/google/go-cmp v0.6.0
 	go.uber.org/zap v1.26.0
 	tailscale.com v1.62.0
 )
@@ -62,7 +63,6 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/cel-go v0.15.1 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/nftables v0.1.1-0.20230115205135-9aa6fdf5a28c // indirect
 	github.com/google/pprof v0.0.0-20230808223545-4887780b67fb // indirect
 	github.com/google/uuid v1.5.0 // indirect

--- a/module.go
+++ b/module.go
@@ -22,6 +22,7 @@ import (
 
 var (
 	servers = caddy.NewUsagePool()
+	app     = caddy.NewUsagePool()
 )
 
 func init() {

--- a/module.go
+++ b/module.go
@@ -106,12 +106,8 @@ func getServer(_, addr string) (*tsnetServerDestructor, error) {
 		}
 
 		if host != "" {
-			// Set authkey to "TS_AUTHKEY_<HOST>".  If empty,
-			// fall back to "TS_AUTHKEY".
-			s.AuthKey = os.Getenv("TS_AUTHKEY_" + strings.ToUpper(host))
-			if s.AuthKey == "" {
-				s.AuthKey = os.Getenv("TS_AUTHKEY")
-			}
+			s.AuthKey = getAuthKey(host)
+			log.Println("auth_key", s.AuthKey)
 
 			// Set config directory for tsnet.  By default, tsnet will use the name of the
 			// running program, but we include the hostname as well so that a single
@@ -135,6 +131,21 @@ func getServer(_, addr string) (*tsnetServerDestructor, error) {
 	}
 
 	return s.(*tsnetServerDestructor), nil
+}
+
+func getAuthKey(host string) string {
+	storedAuthKey, loaded := app.LoadOrStore(authUsageKey, "")
+	if loaded {
+		return storedAuthKey.(string)
+	}
+
+	// Set authkey to "TS_AUTHKEY_<HOST>".  If empty,
+	// fall back to "TS_AUTHKEY".
+	authKey := os.Getenv("TS_AUTHKEY_" + strings.ToUpper(host))
+	if authKey == "" {
+		authKey = os.Getenv("TS_AUTHKEY")
+	}
+	return authKey
 }
 
 type TailscaleAuth struct {

--- a/module.go
+++ b/module.go
@@ -107,7 +107,6 @@ func getServer(_, addr string) (*tsnetServerDestructor, error) {
 
 		if host != "" {
 			s.AuthKey = getAuthKey(host)
-			log.Println("auth_key", s.AuthKey)
 
 			// Set config directory for tsnet.  By default, tsnet will use the name of the
 			// running program, but we include the hostname as well so that a single
@@ -134,6 +133,11 @@ func getServer(_, addr string) (*tsnetServerDestructor, error) {
 }
 
 func getAuthKey(host string) string {
+	hostAuthKey, loaded := app.LoadOrStore(host, "")
+	if loaded {
+		return hostAuthKey.(TSServer).AuthKey
+	}
+
 	storedAuthKey, loaded := app.LoadOrStore(authUsageKey, "")
 	if loaded {
 		return storedAuthKey.(string)

--- a/module.go
+++ b/module.go
@@ -283,7 +283,10 @@ type tsnetServerListener struct {
 }
 
 func (t *tsnetServerListener) Close() error {
-	fmt.Println("Delete", t.hostname)
+	if err := t.Listener.Close(); err != nil {
+		return err
+	}
+
 	_, err := servers.Delete(t.hostname)
 	return err
 }

--- a/module_test.go
+++ b/module_test.go
@@ -1,0 +1,65 @@
+package tscaddy
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+)
+
+func Test_GetAuthKey(t *testing.T) {
+
+	const testkey = "abcdefghijklmnopqrstuvwxyz"
+	const testHostKey = "1234567890"
+	const testenvkey = "zyxwvutsrqponmlkjihgfedca"
+	const testHost = "unittest"
+
+	tests := map[string]struct {
+		host    string
+		skipApp bool
+		want    string
+	}{
+		"default key from module": {
+			want: testkey,
+			host: "testhost",
+		},
+		"default key from environment": {
+			want:    testenvkey,
+			skipApp: true,
+			host:    "testhost",
+		},
+		"host key from module": {
+			want: testHostKey,
+			host: testHost,
+		},
+		"host key from environment": {
+			want: testHostKey,
+			host: testHost,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			app = caddy.NewUsagePool()
+			if !tt.skipApp {
+				app.LoadOrStore(authUsageKey, testkey)
+				app.LoadOrStore(testHost, TSServer{
+					AuthKey: testHostKey,
+				})
+			}
+			os.Setenv("TS_AUTHKEY", testenvkey)
+			hostKey := fmt.Sprintf("TS_AUTHKEY_%s", strings.ToUpper(testHost))
+			os.Setenv(hostKey, testHostKey)
+			t.Cleanup(func() {
+				os.Unsetenv("TS_AUTHKEY")
+				os.Unsetenv(hostKey)
+			})
+
+			got := getAuthKey(tt.host)
+			if got != tt.want {
+				t.Errorf("GetAuthKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/module_test.go
+++ b/module_test.go
@@ -1,7 +1,9 @@
 package tscaddy
 
 import (
+	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"testing"
 )
@@ -53,5 +55,32 @@ func Test_GetAuthKey(t *testing.T) {
 				t.Errorf("GetAuthKey() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func Test_Listen(t *testing.T) {
+	svr, err := getServer("", "testhost")
+	if err != nil {
+		t.Fatal("failed to get server", err)
+	}
+
+	ln, err := svr.Listen("tcp", ":80")
+	if err != nil {
+		t.Fatal("failed to listen", err)
+	}
+	count, exists := servers.References("testhost")
+	if !exists && count != 1 {
+		t.Fatal("reference doesn't exist")
+	}
+	ln.Close()
+
+	count, exists = servers.References("testhost")
+	if exists && count != 0 {
+		t.Fatal("reference exists when it shouldn't")
+	}
+
+	err = svr.Close()
+	if !errors.Is(err, net.ErrClosed) {
+		t.Fatal("unexpected error", err)
 	}
 }

--- a/module_test.go
+++ b/module_test.go
@@ -37,7 +37,7 @@ func Test_GetAuthKey(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			app = &TSApp{
+			app := &TSApp{
 				Servers: make(map[string]TSServer),
 			}
 			if !tt.skipApp {

--- a/module_test.go
+++ b/module_test.go
@@ -35,8 +35,9 @@ func Test_GetAuthKey(t *testing.T) {
 			host: testHost,
 		},
 		"host key from environment": {
-			want: testHostKey,
-			host: testHost,
+			want:    testHostKey,
+			skipApp: true,
+			host:    testHost,
 		},
 	}
 	for name, tt := range tests {


### PR DESCRIPTION
As described in #24, this PR creates a new Caddy module registering a global configuration
option and a module fulfilling the required interface. This is an initial implementation using a
global `caddy.UsagePool` to share the configuration between the application parsed from the
caddyfile and the standalone listener functions. This will also fallback to the environment if the
configuration wasn't parsed from the Caddyfile.

In the future this can support ephemeral servers by marking the servers as ephemeral based
on the Caddy config and then stopping them in the `Stop` function. 