### PR TITLE
set tsapp singleton during Provision step

### DIFF
--- a/app.go
+++ b/app.go
@@ -37,18 +37,22 @@ func (TSApp) CaddyModule() caddy.ModuleInfo {
 
 func (t *TSApp) Provision(ctx caddy.Context) error {
 	t.logger = ctx.Logger(t)
-	return nil
-}
-
-func (t *TSApp) Start() error {
 	tsapp.Store(t)
 	return nil
 }
 
-func (t *TSApp) Stop() error {
+func (t *TSApp) Cleanup() error {
 	tsapp.CompareAndSwap(t, nil)
 	return nil
 }
 
+// Implement the caddy.App interface, but these are no-ops for TSApp,
+// since everything is done in Provision and Cleanup.
+// This ensures the Tailscale config is available early for configuring
+// things like network listeners.
+func (t *TSApp) Start() error { return nil }
+func (t *TSApp) Stop() error  { return nil }
+
 var _ caddy.App = (*TSApp)(nil)
 var _ caddy.Provisioner = (*TSApp)(nil)
+var _ caddy.CleanerUpper = (*TSApp)(nil)

--- a/module.go
+++ b/module.go
@@ -154,7 +154,9 @@ func getAuthKey(host string, app *TSApp) string {
 	// If empty, fall back to "TS_AUTHKEY".
 	authKey := os.Getenv("TS_AUTHKEY_" + strings.ToUpper(host))
 	if authKey != "" {
-		app.logger.Warn("Relying on TS_AUTHKEY_{HOST} env var is deprecated. Set caddy config instead.", zap.Any("host", host))
+		if app.logger != nil {
+			app.logger.Warn("Relying on TS_AUTHKEY_{HOST} env var is deprecated. Set caddy config instead.", zap.Any("host", host))
+		}
 		return authKey
 	}
 


### PR DESCRIPTION
It seems that Start() is called too late for some configurations. Instead, set the tsapp singleton during Provision, and implement the accompanying CleanerUpper interface.  We still have Start and Stop since they are required by caddy.App, but they are now noops.

I discovered this was an issue by changing the environment variable `auth_key` was pulling from, and discovering that the global tsapp hadn't actually been started yet.

cc @clly 