### PR TITLE
use new tsnet logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,19 +85,7 @@ Supported options are:
 
 All configuration values are optional, though an [auth key] is strongly recommended.
 If no auth key is present, one will be loaded from the default `$TS_AUTHKEY` environment variable.
-Failing that, it will log an auth URL to the Caddy log at `DEBUG` level.
-Because these logs can be quite noisy, they must be enabled with the [debug option]
-or with a [named logger]:
-
-```caddyfile
-{
-  log tailscale {
-    output stdout
-    level DEBUG
-    include tailscale
-  }
-}
-```
+Failing that, it will log an auth URL to the Caddy log that can be used to register the node.
 
 After the node had been added to your network, you can restart Caddy without the debug logging.
 Unless the node is registered as `ephemeral`, the auth key is only needed on first run.

--- a/module.go
+++ b/module.go
@@ -106,6 +106,9 @@ func getNode(ctx caddy.Context, name string) (*tailscaleNode, error) {
 			Logf: func(format string, args ...any) {
 				app.logger.Sugar().Debugf(format, args...)
 			},
+			UserLogf: func(format string, args ...any) {
+				app.logger.Sugar().Infof(format, args...)
+			},
 			Ephemeral:    getEphemeral(name, app),
 			RunWebClient: getWebUI(name, app),
 		}


### PR DESCRIPTION
Send UserLogf messages to caddy log at INFO level. Remove instructions for enabling debug logging to get the auth URL.