### PR TITLE
transport: add TLS support

### DIFF
--- a/module.go
+++ b/module.go
@@ -42,11 +42,7 @@ func getPlainListener(c context.Context, _ string, addr string, _ net.ListenConf
 	if network == "" {
 		network = "tcp"
 	}
-
-	ln := &tailscaleNode{
-		Server: s.Server,
-	}
-	return ln.Listen(network, ":"+port)
+	return s.Listen(network, ":"+port)
 }
 
 func getTLSListener(c context.Context, _ string, addr string, _ net.ListenConfig) (any, error) {


### PR DESCRIPTION
Implement reverseproxy.TLSTransport.  We go ahead and store the provided TLSConfig object, but for now we only use it to indicate that we should use TLS.  We don't actually use any of the provided values to configure the client.

Fixes #25