### PR TITLE
use tailscale cert manager with tailscale-proxy command

### DIFF
--- a/examples/proxyauth.caddyfile
+++ b/examples/proxyauth.caddyfile
@@ -10,7 +10,6 @@
 
 {
   order tailscale_auth after basicauth
-  auto_https off
   tailscale {
     ephemeral # create all nodes as ephemeral
   }


### PR DESCRIPTION
Instruct caddy to use the tailscale cert manager.  Also add a --debug flag to enable debug logging with the tailscale-proxy command.

Also remove a lingering `auto_https off` config in one of our examples.

Fixes #27