### PR TITLE
set correct tailnet name in authentication provider

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -98,10 +98,7 @@ func (ta Auth) Authenticate(w http.ResponseWriter, r *http.Request) (caddyauth.U
 	var tailnet string
 	if !info.Node.Hostinfo.ShareeNode() {
 		if s, found := strings.CutPrefix(info.Node.Name, info.Node.ComputedName+"."); found {
-			// TODO(will): Update this for current ts.net magicdns hostnames.
-			if s, found := strings.CutSuffix(s, ".beta.tailscale.net."); found {
-				tailnet = s
-			}
+			tailnet = strings.TrimSuffix(s, ".")
 		}
 	}
 

--- a/examples/proxyauth.caddyfile
+++ b/examples/proxyauth.caddyfile
@@ -25,6 +25,7 @@
   tailscale_auth
   reverse_proxy localhost:3333 {
     header_up X-Webauth-User {http.auth.user.tailscale_login}
+    header_up X-Tailscale-Tailnet {http.auth.user.tailscale_tailnet}
   }
 }
 
@@ -37,6 +38,7 @@
   tailscale_auth
   reverse_proxy localhost:3333 {
     header_up X-Webauth-User {http.auth.user.tailscale_login}
+    header_up X-Tailscale-Tailnet {http.auth.user.tailscale_tailnet}
   }
 }
 
@@ -47,5 +49,5 @@
 # But for an actual application, this could immediately log the user in.
 :3333 {
   templates
-  respond `Hello, {{.Req.Header.Get "X-Webauth-User"}}`
+  respond `Hello, {{.Req.Header.Get "X-Webauth-User"}} from {{.Req.Header.Get "X-Tailscale-Tailnet"}}`
 }


### PR DESCRIPTION
The MagicDNS suffix is what we now refer to as the "Tailnet Name": https://tailscale.com/kb/1217/tailnet-name. This code was previously using what we now call the org name, which used to be embedded in the MagicDNS name before we used ts.net cert domains.

Also add tailnet name to the output in the proxyauth example config.

Fixes #29