### PR TITLE
set directive order for tailscale_auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,14 +253,9 @@ as well as set various fields on the Caddy user object that can be passed to app
 For sites listening only on the Tailscale network interface,
 user access will already be enforced by the tailnet access controls.
 
-Set the [order] directive in your global options to instruct Caddy when to process `tailscale_auth`.
 For example, in a Caddyfile:
 
 ```caddyfile
-{
-  order tailscale_auth after basicauth
-}
-
 :80 {
   tailscale_auth
 }
@@ -294,7 +289,6 @@ You might have something like the following in your Caddyfile:
 When used with a Tailscale listener (described above), that Tailscale node is used to identify the remote user.
 Otherwise, the authentication provider will attempt to connect to the Tailscale daemon running on the local machine.
 
-[order]: https://caddyserver.com/docs/caddyfile/options#order
 [Gitea]: https://docs.gitea.com/usage/authentication#reverse-proxy
 [Grafana]: https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/auth-proxy/
 

--- a/auth.go
+++ b/auth.go
@@ -19,6 +19,7 @@ import (
 func init() {
 	caddy.RegisterModule(Auth{})
 	httpcaddyfile.RegisterHandlerDirective("tailscale_auth", parseAuthConfig)
+	httpcaddyfile.RegisterDirectiveOrder("tailscale_auth", httpcaddyfile.After, "basicauth")
 }
 
 // Auth is an HTTP authentication provider that authenticates users based on their Tailscale identity.

--- a/examples/auth.caddyfile
+++ b/examples/auth.caddyfile
@@ -5,7 +5,6 @@
 # Run this configuration and then visit <http://caddytest/>.
 
 {
-  order tailscale_auth after basicauth
   tailscale {
     ephemeral # create all nodes as ephemeral
   }

--- a/examples/proxyauth.caddyfile
+++ b/examples/proxyauth.caddyfile
@@ -9,7 +9,6 @@
 # and be available at <https://caddytest.your-tailnet.ts.net>.
 
 {
-  order tailscale_auth after basicauth
   tailscale {
     ephemeral # create all nodes as ephemeral
   }


### PR DESCRIPTION
Now that we require Caddy 2.8, we can use the new RegisterDirectiveOrder func to specify the ordering of the `tailscale_auth` directive, rather than instructing users to set it manually.