### PR TITLE
no need to specify caddy adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ See the comments in the individual files for details.
 Run them with:
 
 ```
-TS_AUTHKEY=<tskey-auth-XXXXX> \
-./caddy run -a caddyfile -c examples/<file>
+TS_AUTHKEY=<tskey-auth-XXXXX> ./caddy run -c examples/<file>
 ```
 
 [examples directory]: ./examples/


### PR DESCRIPTION
caddy 2.8.4 fixed an issue with detecting caddyfiles, so we no longer need to explicitly specify the adapter type, since all of our config files end in `.caddyfile`.