### PR TITLE
add missing license headers in go files 

### DIFF
--- a/addresses.go
+++ b/addresses.go
@@ -1,16 +1,5 @@
 // Copyright 2015 Matthew Holt and The Caddy Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package tscaddy
 

--- a/app.go
+++ b/app.go
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: Apache-2.0
+
 package tscaddy
 
 // app.go contains App and Node, which provide global configuration for registering Tailscale nodes.

--- a/app_test.go
+++ b/app_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: Apache-2.0
+
 package tscaddy
 
 import (

--- a/auth.go
+++ b/auth.go
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: Apache-2.0
+
 package tscaddy
 
 // auth.go contains the TailscaleAuth module and supporting logic.

--- a/command.go
+++ b/command.go
@@ -1,16 +1,6 @@
 // Copyright 2015 Matthew Holt and The Caddy Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: Apache-2.0
 
 package tscaddy
 

--- a/module.go
+++ b/module.go
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: Apache-2.0
+
 // Package tscaddy provides a set of Caddy modules to integrate Tailscale into Caddy.
 package tscaddy
 

--- a/module_test.go
+++ b/module_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: Apache-2.0
+
 package tscaddy
 
 import (

--- a/transport.go
+++ b/transport.go
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: Apache-2.0
+
 package tscaddy
 
 // transport.go contains the Transport module.


### PR DESCRIPTION
Files copied from caddy carry the original copyright and license, though we've switched to the shorter (but equivalent) SPDX identifier. Of those, ones the we further modified for our needs also carry a Tailscale copyright.
