### PR TITLE
Fix auth.go not finding the tsnet.Listener.

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -45,6 +45,9 @@ func (Auth) CaddyModule() caddy.ModuleInfo {
 // findTsnetListener recursively searches ln for embedded child net.Listener structs
 // until it finds the tsnetListener or runs out.
 // the 2nd return value is true if it was found, false if it wasn't.
+//
+// In the future consider alternative approach if Caddy supports unwrapping listeners.
+// See discussion in https://github.com/tailscale/caddy-tailscale/pull/70
 func findTsnetListener(ln net.Listener) (tsnetListener, bool) {
 	// if the input is a tsnetListener, return it.
 	if tsn, ok := ln.(tsnetListener); ok {

--- a/auth.go
+++ b/auth.go
@@ -52,11 +52,13 @@ func (ta *Auth) client(r *http.Request) (*tailscale.LocalClient, error) {
 	// server.
 	server := r.Context().Value(caddyhttp.ServerCtxKey).(*caddyhttp.Server)
 	for _, listener := range server.Listeners() {
-		if tsl, ok := listener.(tsnetListener); ok {
-			var err error
-			ta.localclient, err = tsl.Server().LocalClient()
-			if err != nil {
-				return nil, err
+		if tsServerListener, ok := listener.(*tsnetServerListener); ok {
+			if tsl, ok := tsServerListener.Listener.(tsnetListener); ok {
+				var err error
+				ta.localclient, err = tsl.Server().LocalClient()
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	}

--- a/module.go
+++ b/module.go
@@ -306,6 +306,13 @@ type tsnetServerListener struct {
 	net.Listener
 }
 
+func (t *tsnetServerListener) Unwrap() net.Listener {
+	if t == nil {
+		return nil
+	}
+	return t.Listener
+}
+
 func (t *tsnetServerListener) Close() error {
 	if err := t.Listener.Close(); err != nil {
 		return err


### PR DESCRIPTION
This fixes #68 

`auth.go` was treating the listener as if it was a `tsnet.Listener`, but it was actually a `tsServerListener` which had a member (`Listener`) that implemented `tsnet.Listener`. This caused it to fall-through and try to authenticate the request through a locally-running `tailscaled`, which would fail if caddy was running in a container without one.

I'm not very familiar with go so IDK if there's a less messy-looking way to do this.