### PR TITLE
Change type signatures for Caddy v2.9.0

### DIFF
--- a/module.go
+++ b/module.go
@@ -43,7 +43,7 @@ func init() {
 	hostinfo.SetApp("caddy")
 }
 
-func getTCPListener(c context.Context, _ string, addr string, _ net.ListenConfig) (any, error) {
+func getTCPListener(c context.Context, _ string, _ string, _ string, _ uint, addr string, _ net.ListenConfig) (any, error) {
 	ctx, ok := c.(caddy.Context)
 	if !ok {
 		return nil, fmt.Errorf("context is not a caddy.Context: %T", c)
@@ -65,7 +65,7 @@ func getTCPListener(c context.Context, _ string, addr string, _ net.ListenConfig
 	return s.Listen(network, ":"+port)
 }
 
-func getTLSListener(c context.Context, _ string, addr string, _ net.ListenConfig) (any, error) {
+func getTLSListener(c context.Context, _ string, _ string, _ string, _ uint, addr string, _ net.ListenConfig) (any, error) {
 	ctx, ok := c.(caddy.Context)
 	if !ok {
 		return nil, fmt.Errorf("context is not a caddy.Context: %T", c)
@@ -98,7 +98,7 @@ func getTLSListener(c context.Context, _ string, addr string, _ net.ListenConfig
 	return ln, nil
 }
 
-func getUDPListener(c context.Context, _ string, addr string, _ net.ListenConfig) (any, error) {
+func getUDPListener(c context.Context, _ string, _ string, _ string, _ uint, addr string, _ net.ListenConfig) (any, error) {
 	ctx, ok := c.(caddy.Context)
 	if !ok {
 		return nil, fmt.Errorf("context is not a caddy.Context: %T", c)


### PR DESCRIPTION
Changed type signatures of `getTCPListener`, `getUDPListener` and `getTLSListener`, to make these functions respect ListenerFunc.
Resolves #85.