### PR TITLE
Fix typo in Docker run command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ caddy-tailscale includes a Dockerfile for building a Caddy image with the plugin
 This can be built manually, or you can use the pre-built image with:
 
 ```sh
-docker run -it -rm ghcr.io/tailscale/caddy-tailscale
+docker run -it --rm ghcr.io/tailscale/caddy-tailscale
 ```
 
 Mount a custom Caddyfile to `/etc/caddy/Caddyfile` and optionally mount a volume
 to `/config` to persist the default Tailscale state directory:
 
 ```sh
-docker run -it -rm \
+docker run -it --rm \
   -e TS_AUTHKEY="tskey-auth-XXX" \
   -v ./custom.caddyfile:/etc/caddy/Caddyfile -v ./config:config \
   ghcr.io/tailscale/caddy-tailscale


### PR DESCRIPTION
docker build takes --rm argument, -rm does not exist