### PR TITLE
Fixing Dockerfile warnings 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ COPY --from=build /work/caddy /usr/bin/caddy
 COPY examples/simple.caddyfile /etc/caddy/Caddyfile
 
 # See https://caddyserver.com/docs/conventions#file-locations for details
-ENV XDG_CONFIG_HOME /config
-ENV XDG_DATA_HOME /data
+ENV XDG_CONFIG_HOME=/config
+ENV XDG_DATA_HOME=/data
 
 EXPOSE 80
 EXPOSE 443


### PR DESCRIPTION
- FROM & AS have same casing 
- Use key=value rather than the legacy "key value" format