### PR TITLE
fix: check if innerLn is valid before is zero.

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -73,7 +73,7 @@ func findTsnetListener(ln net.Listener) (_ tsnetListener, ok bool) {
 	}
 
 	innerLn := s.FieldByName("Listener")
-	if innerLn.IsZero() {
+	if !innerLn.IsValid() || innerLn.IsZero() {
 		// no more child/embedded listeners left
 		return nil, false
 	}


### PR DESCRIPTION
Fixes #120.

Apparently, [`IsZero()` only works for valid zero values for the underlying type](https://github.com/golang/go/issues/46320), which in this case it's apparently not.
