### PR TITLE
all: cleanup minor linting issues and license language

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,4 +1,4 @@
-// Copyright (c) Tailscale Inc & AUTHORS
+// Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package tscaddy

--- a/app_test.go
+++ b/app_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Tailscale Inc & AUTHORS
+// Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package tscaddy

--- a/auth.go
+++ b/auth.go
@@ -1,4 +1,4 @@
-// Copyright (c) Tailscale Inc & AUTHORS
+// Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package tscaddy
@@ -17,7 +17,7 @@ import (
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/caddyauth"
-	"tailscale.com/client/tailscale"
+	"tailscale.com/client/local"
 	"tailscale.com/tsnet"
 )
 
@@ -32,7 +32,7 @@ func init() {
 // that node will be used to identify the user information for inbound requests.
 // Otherwise, it will attempt to find and use the local tailscaled daemon running on the system.
 type Auth struct {
-	localclient *tailscale.LocalClient
+	localclient *local.Client
 }
 
 func (Auth) CaddyModule() caddy.ModuleInfo {
@@ -65,7 +65,7 @@ func findTsnetListener(ln net.Listener) (_ tsnetListener, ok bool) {
 
 	// if ln has an embedded net.Listener field, unwrap it.
 	s := reflect.ValueOf(ln)
-	if s.Kind() == reflect.Ptr {
+	if s.Kind() == reflect.Pointer {
 		s = s.Elem()
 	}
 	if s.Kind() != reflect.Struct {
@@ -93,7 +93,7 @@ type wrappedListener interface {
 // client returns the tailscale LocalClient for the TailscaleAuth module.
 // If the LocalClient has not already been configured, the provided request will be used to
 // lookup the tailscale node that serviced the request, and get the associated LocalClient.
-func (ta *Auth) client(r *http.Request) (*tailscale.LocalClient, error) {
+func (ta *Auth) client(r *http.Request) (*local.Client, error) {
 	if ta.localclient != nil {
 		return ta.localclient, nil
 	}
@@ -113,7 +113,7 @@ func (ta *Auth) client(r *http.Request) (*tailscale.LocalClient, error) {
 
 	if ta.localclient == nil {
 		// default to empty client that will talk to local tailscaled
-		ta.localclient = new(tailscale.LocalClient)
+		ta.localclient = new(local.Client)
 	}
 
 	return ta.localclient, nil

--- a/cmd/caddy/main.go
+++ b/cmd/caddy/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) Tailscale Inc & AUTHORS
+// Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/command.go
+++ b/command.go
@@ -1,5 +1,5 @@
 // Copyright 2015 Matthew Holt and The Caddy Authors
-// Copyright (c) Tailscale Inc & AUTHORS
+// Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package tscaddy
@@ -109,9 +109,10 @@ func cmdTailscaleProxy(fs caddycmd.Flags) (int, error) {
 		}
 	}
 	if fromAddr.Port == "" {
-		if fromAddr.Scheme == "http" {
+		switch fromAddr.Scheme {
+		case "http":
 			fromAddr.Port = httpPort
-		} else if fromAddr.Scheme == "https" {
+		case "https":
 			fromAddr.Port = httpsPort
 		}
 	}

--- a/module_test.go
+++ b/module_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Tailscale Inc & AUTHORS
+// Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package tscaddy
@@ -449,7 +449,7 @@ func Test_Listen(t *testing.T) {
 	}
 
 	// Close the listener
-	ln.(io.Closer).Close()
+	must.Do(ln.(io.Closer).Close())
 
 	// Check that listener reference is gone
 	lcount, lexists = tailscaleListeners.References(listenerKey)

--- a/transport.go
+++ b/transport.go
@@ -1,4 +1,4 @@
-// Copyright (c) Tailscale Inc & AUTHORS
+// Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package tscaddy


### PR DESCRIPTION
- change "AUTHORS" to "contributors" in copyright line, since we don't maintain an AUTHORS file in this repo.
- fix use of deprecated tailscale.LocalClient
- remove embedded fields in selector when not needed
- add some missing error checks

Updates #cleanup

Change-Id: Ia101a4a3005adb9118051b3416f5a64a4a45987d