### PR TITLE
auth: support tagged nodes in tailscale_auth

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,12 +1,15 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+// Patched by Replit to support tagged nodes in tailscale_auth.
+// Upstream rejects all tagged nodes; this version exposes tags as metadata
+// so Caddy expressions can match on {http.auth.user.tailscale_tags}.
+
 package tscaddy
 
 // auth.go contains the TailscaleAuth module and supporting logic.
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 	"reflect"
@@ -126,12 +129,18 @@ type tsnetListener interface {
 
 // Authenticate authenticates the request and sets Tailscale user data on the caddy User object.
 //
-// This method will set the following user metadata:
+// For regular (non-tagged) users, the following metadata is set:
 //   - tailscale_login: the user's login name without the domain
 //   - tailscale_user: the user's full login name
 //   - tailscale_name: the user's display name
 //   - tailscale_profile_picture: the user's profile picture URL
-//   - tailscale_tailnet: the user's tailnet name (if the user is not connecting to a shared node)
+//   - tailscale_tailnet: the user's tailnet name
+//
+// For tagged nodes, the following metadata is set:
+//   - tailscale_tags: comma-separated list of node tags (e.g. "tag:zergbot,tag:ci")
+//   - tailscale_tailnet: the tailnet name
+//
+// The user ID is set to the login name for regular users, or the first tag for tagged nodes.
 func (ta Auth) Authenticate(w http.ResponseWriter, r *http.Request) (caddyauth.User, bool, error) {
 	user := caddyauth.User{}
 
@@ -145,10 +154,6 @@ func (ta Auth) Authenticate(w http.ResponseWriter, r *http.Request) (caddyauth.U
 		return user, false, err
 	}
 
-	if len(info.Node.Tags) != 0 {
-		return user, false, fmt.Errorf("node %s has tags", info.Node.Hostinfo.Hostname())
-	}
-
 	var tailnet string
 	if !info.Node.Hostinfo.ShareeNode() {
 		if s, found := strings.CutPrefix(info.Node.Name, info.Node.ComputedName+"."); found {
@@ -156,14 +161,25 @@ func (ta Auth) Authenticate(w http.ResponseWriter, r *http.Request) (caddyauth.U
 		}
 	}
 
-	user.ID = info.UserProfile.LoginName
-	user.Metadata = map[string]string{
-		"tailscale_login":           strings.Split(info.UserProfile.LoginName, "@")[0],
-		"tailscale_user":            info.UserProfile.LoginName,
-		"tailscale_name":            info.UserProfile.DisplayName,
-		"tailscale_profile_picture": info.UserProfile.ProfilePicURL,
-		"tailscale_tailnet":         tailnet,
+	if len(info.Node.Tags) != 0 {
+		// Tagged node: expose tags as metadata for Caddy expression matching.
+		// user.ID is set to the first tag for convenient @matcher expressions.
+		user.ID = info.Node.Tags[0]
+		user.Metadata = map[string]string{
+			"tailscale_tags":    strings.Join(info.Node.Tags, ","),
+			"tailscale_tailnet": tailnet,
+		}
+	} else {
+		user.ID = info.UserProfile.LoginName
+		user.Metadata = map[string]string{
+			"tailscale_login":           strings.Split(info.UserProfile.LoginName, "@")[0],
+			"tailscale_user":            info.UserProfile.LoginName,
+			"tailscale_name":            info.UserProfile.DisplayName,
+			"tailscale_profile_picture": info.UserProfile.ProfilePicURL,
+			"tailscale_tailnet":         tailnet,
+		}
 	}
+
 	return user, true, nil
 }
 

--- a/auth.go
+++ b/auth.go
@@ -1,10 +1,6 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// Patched by Replit to support tagged nodes in tailscale_auth.
-// Upstream rejects all tagged nodes; this version exposes tags as metadata
-// so Caddy expressions can match on {http.auth.user.tailscale_tags}.
-
 package tscaddy
 
 // auth.go contains the TailscaleAuth module and supporting logic.
@@ -177,6 +173,7 @@ func (ta Auth) Authenticate(w http.ResponseWriter, r *http.Request) (caddyauth.U
 			"tailscale_name":            info.UserProfile.DisplayName,
 			"tailscale_profile_picture": info.UserProfile.ProfilePicURL,
 			"tailscale_tailnet":         tailnet,
+			"tailscale_tags":            "",
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Accept tagged Tailscale nodes in `tailscale_auth` instead of rejecting them with an error
- Expose node tags as `tailscale_tags` metadata for Caddy expression matching
- Set `user.ID` to the first tag for convenient `@matcher` expressions

## Motivation

Currently, `tailscale_auth` unconditionally rejects all tagged nodes:

```go
if len(info.Node.Tags) != 0 {
    return user, false, fmt.Errorf("node %s has tags", info.Node.Hostinfo.Hostname())
}
```

This makes it impossible to use `tailscale_auth` with tagged infrastructure nodes (CI bots, service accounts, etc.) that need access to Caddy-protected services. Many Tailscale deployments use [ACL tags](https://tailscale.com/kb/1068/acl-tags) to manage access for non-human nodes, and these nodes are currently locked out of any service using `tailscale_auth`.

## What this changes

For **tagged nodes**, `Authenticate` now returns `(user, true, nil)` with:
- `user.ID` = first tag (e.g. `tag:ci`)
- `tailscale_tags` metadata = comma-separated list of all tags (e.g. `"tag:ci,tag:deploy"`)
- `tailscale_tailnet` metadata = tailnet name

For **regular (non-tagged) users**, behavior is completely unchanged.

## Example usage

With this change, Caddyfile expressions can match on tagged nodes:

```caddyfile
@ci expression {http.auth.user.tailscale_tags}.contains("tag:ci")
reverse_proxy @ci localhost:8080

@admin expression {http.auth.user.id} == "admin@example.com" || {http.auth.user.tailscale_tags}.contains("tag:admin")
reverse_proxy @admin localhost:9090
```

This enables granting tagged infrastructure nodes (CI runners, monitoring agents, service-to-service communication) access to protected endpoints alongside regular users.